### PR TITLE
Simplify

### DIFF
--- a/src/Control/Monad/STE.hs
+++ b/src/Control/Monad/STE.hs
@@ -2,8 +2,11 @@
 module Control.Monad.STE
 (
   STE
+  ,runSTE2
+  ,runSTEither
   ,runSTE
   ,throwSTE
+  ,handleSTE2
   ,handleSTE
   )
 


### PR DESCRIPTION
- Get rid of the weird boxing stuff in favor of `Any`, the
  officially-approved `unsafeCoerce` target.
- Pull the `Either`s out of the basic implementation.
- Expose a dual-continuation version and a simple direct version
  of `runSTE`.
